### PR TITLE
Fix requirements

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -2,7 +2,7 @@
 
 # Our fork of security, can be synced when this is merged: https://github.com/geerlingguy/ansible-role-security/pull/16
 - name: geerlingguy.security
-  version: '0b495a931c3d9c73732e14811c74bc70635d6c69'
+  version: 'origin/jbzdak/notify-mail'
   src: https://github.com/open-craft/ansible-role-security
 
 - name: geerlingguy.nginx


### PR DESCRIPTION
Until we merge role upstream it's safer to use a branch than hash (as rebase can destroy the hash). 
