### PR TITLE
Move tarsnap variables for Dalite to the play.

### DIFF
--- a/deploy-all.yml
+++ b/deploy-all.yml
@@ -9,7 +9,18 @@
   hosts: dalite
   become: true
   roles:
-    - common-server
+    - name: common-server
+      TARSNAP_KEY: "{{ DALITE_LOGROTATE_TARSNAP_KEY }}"
+      TARSNAP_KEY_REMOTE_LOCATION: "/root/tarsnap-logrotate.key"
+      TARSNAP_BACKUP_PRE_SCRIPT: "/usr/local/sbin/dalite-pre-backup.sh"
+      TARSNAP_BACKUP_SCRIPT_LOCATION: "{{ DALITE_TARSNAP_BACKUP_SCRIPT }}"
+      TARSNAP_ARCHIVE_NAME: "dalite-logs"
+      TARSNAP_CACHE: "/var/cache/tarsnap-logrotate"
+      TARSNAP_BACKUP_FOLDERS: "{{ DALITE_LOG_DOWNLOAD_LOG_DIR }} {{ DALITE_LOG_DOWNLOAD_DB_DIR }}"
+      TARSNAP_BACKUP_SNITCH: "{{ DALITE_LOG_TARSNAP_SNITCH }}"
+      # Backup of logs is initiated by logrotate, which incidentally
+      # also creates data to be backed up.
+      TARSNAP_CRONTAB_STATE: "absent"
     - forward-server-mail
     - dalite
     - backup-swift-container

--- a/group_vars/dalite/public.yml
+++ b/group_vars/dalite/public.yml
@@ -35,18 +35,6 @@ SANITY_CHECK_COMMANDS:
   - command: "{{ DALITE_MANAGE_PY }} sanity_check"
     message: "Sanity check failed for Dalite. Is database accessible?"
 
-TARSNAP_KEY: "{{ DALITE_LOGROTATE_TARSNAP_KEY }}"
-TARSNAP_KEY_REMOTE_LOCATION: "/root/tarsnap-logrotate.key"
-TARSNAP_BACKUP_PRE_SCRIPT: "/usr/local/sbin/dalite-pre-backup.sh"
-TARSNAP_BACKUP_SCRIPT_LOCATION: "{{ DALITE_TARSNAP_BACKUP_SCRIPT }}"
-TARSNAP_ARCHIVE_NAME: "dalite-logs"
-TARSNAP_CACHE: "/var/cache/tarsnap-logrotate"
-TARSNAP_BACKUP_FOLDERS: "{{ DALITE_LOG_DOWNLOAD_LOG_DIR }} {{ DALITE_LOG_DOWNLOAD_DB_DIR }}"
-TARSNAP_BACKUP_SNITCH: "{{ DALITE_LOG_TARSNAP_SNITCH }}"
-# Backup of logs is initiated by logrotate, which incidentally
-# also creates data to be backed up.
-TARSNAP_CRONTAB_STATE: "absent"
-
 BACKUP_SWIFT_CONTAINER: "{{ DALITE_MEDIA_CONTAINER }}"
 BACKUP_SWIFT_LOCAL_DIR: '/var/cache/dalite-swift-backup'
 BACKUP_SWIFT_BACKUP_NAME: 'dalite-swift-backup'

--- a/requirements.yml
+++ b/requirements.yml
@@ -19,7 +19,7 @@
 
 - name: backup-to-tarsnap
   src: https://github.com/open-craft/ansible-backup-to-tarsnap
-  version: '3d2f6f982ab02112ede9e39e1553b106e5079b87'
+  version: 45ac5b4bfd9fe4003c126c3284bb0a91ac48b86a
 
 - name: common-server
   src: https://github.com/open-craft/ansible-common-server


### PR DESCRIPTION
This works around Ansible's broken variable precendence rules for the case that a role gets included multiple times.