### PR TITLE
Added play for deploying standalone RabbitMQ instances

### DIFF
--- a/deploy-all.yml
+++ b/deploy-all.yml
@@ -1,5 +1,5 @@
 - name: Install Python 2
-  hosts: load-balancer
+  hosts: load-balancer:rabbitmq
   become: true
   gather_facts: false
   tasks:
@@ -32,3 +32,11 @@
     - common-server
     - forward-server-mail
     - load-balancer
+
+- name: Set up rabbitmq servers
+  hosts: rabbitmq
+  become: true
+  roles:
+    - common-server
+    - forward-server-mail
+    - rabbitmq

--- a/group_vars/rabbitmq/public.yml
+++ b/group_vars/rabbitmq/public.yml
@@ -1,0 +1,9 @@
+SANITY_CHECK_LIVE_PORTS:
+  - host: localhost
+    port: 5671
+    message: "RabbitMQ does not respond on port 5671."
+  - host: localhost
+    port: 15671
+    message: "RabbitMQ management does not respond on port 15671."
+
+TARSNAP_BACKUP_FOLDERS: /etc/rabbitmq /var/lib/rabbitmq /etc/letsencrypt

--- a/requirements.yml
+++ b/requirements.yml
@@ -48,3 +48,7 @@
 - name: load-balancer
   src: https://github.com/open-craft/ansible-load-balancer
   version: 4bbeb21d2ad9bedbf5ba54ffcbc26fd05f449b1f
+
+- name: rabbitmq
+  src: https://github.com/open-craft/ansible-rabbitmq
+  version: 1f249e94fb8d4b8166496a5e5bc11c2f213cfae4


### PR DESCRIPTION
This PR adds a play to the `deploy-all` playbook to allow for deploying/managing standalone RabbitMQ instances.