### PR TITLE
Set LOAD_BALANCER_OPS_EMAIL to OPS_EMAIL.

### DIFF
--- a/group_vars/load-balancer/public.yml
+++ b/group_vars/load-balancer/public.yml
@@ -7,3 +7,5 @@ SANITY_CHECK_LIVE_PORTS:
     message: "Load balancer does not respond on port 443."
 
 TARSNAP_BACKUP_FOLDERS: /etc/letsencrypt
+
+LOAD_BALANCER_OPS_EMAIL: "{{ OPS_EMAIL }}"

--- a/requirements.yml
+++ b/requirements.yml
@@ -47,4 +47,4 @@
 
 - name: load-balancer
   src: https://github.com/open-craft/ansible-load-balancer
-  version: f1bf941f2dbe20262b4bce44f636c7f57ab4a7c2
+  version: 4bbeb21d2ad9bedbf5ba54ffcbc26fd05f449b1f


### PR DESCRIPTION
To make the ansible-load-balancer role completely self-contained (which is nice anyway, but was necessary for the integration test playbook), I needed to add another setting for the operator email.  See open-craft/ansible-load-balancer#4 for the corresponding changes in the role repo.