### PR TITLE
Include /etc/haproxy in load balancer backups.

### DIFF
--- a/group_vars/load-balancer/public.yml
+++ b/group_vars/load-balancer/public.yml
@@ -6,7 +6,7 @@ SANITY_CHECK_LIVE_PORTS:
     port: 443
     message: "Load balancer does not respond on port 443."
 
-TARSNAP_BACKUP_FOLDERS: /etc/letsencrypt
+TARSNAP_BACKUP_FOLDERS: "/etc/letsencrypt /etc/haproxy"
 
 LOAD_BALANCER_OPS_EMAIL: "{{ OPS_EMAIL }}"
 


### PR DESCRIPTION
While it should be possible to let the instance manager reconstruct the information in `/etc/haproxy`, we sometimes add manual configuration to that directory:

* temporary configuration fragments to redirect to maintenance pages
* work-arounds for some instances
* externally issued SSL certificates
* a symlink to mark the default certificate

Overall, when restoring a crashed load balancer, it is easier to be able to recover that directory from the backup as well.

The variable `TARSNAP_BACKUP_FOLDERS` gets [directly included in the tarsnap command line](https://github.com/open-craft/ansible-backup-to-tarsnap/blob/master/templates/backup.sh#L18-L20), so a space-separated list of directories works fine.