### PR TITLE
Backup the directory where RabbitMQ definitions are exported

### DIFF
--- a/group_vars/rabbitmq/public.yml
+++ b/group_vars/rabbitmq/public.yml
@@ -6,4 +6,5 @@ SANITY_CHECK_LIVE_PORTS:
     port: 15671
     message: "RabbitMQ management does not respond on port 15671."
 
-TARSNAP_BACKUP_FOLDERS: /usr/local/lib/rabbitmq/backup /etc/rabbitmq /etc/letsencrypt
+TARSNAP_BACKUP_FOLDERS: "{{ RABBITMQ_EXPORT_DIR }} /etc/rabbitmq /etc/letsencrypt"
+TARSNAP_BACKUP_PRE_SCRIPT: "{{ RABBITMQ_SCRIPTS_DIR }}/{{ RABBITMQ_BACKUP_COMMAND }}"

--- a/group_vars/rabbitmq/public.yml
+++ b/group_vars/rabbitmq/public.yml
@@ -6,4 +6,4 @@ SANITY_CHECK_LIVE_PORTS:
     port: 15671
     message: "RabbitMQ management does not respond on port 15671."
 
-TARSNAP_BACKUP_FOLDERS: /etc/rabbitmq /var/lib/rabbitmq /etc/letsencrypt
+TARSNAP_BACKUP_FOLDERS: /usr/local/lib/rabbitmq/backup /etc/rabbitmq /etc/letsencrypt


### PR DESCRIPTION
CC @smarnach 

This change goes along with https://github.com/open-craft/ansible-rabbitmq/pull/6