### PR TITLE
Add play and dependencies to deploy the chat server.

### DIFF
--- a/deploy-all.yml
+++ b/deploy-all.yml
@@ -1,5 +1,5 @@
 - name: Install Python 2
-  hosts: load-balancer:rabbitmq:elasticsearch:relay
+  hosts: load-balancer:rabbitmq:elasticsearch:relay:chat
   become: true
   gather_facts: false
   tasks:
@@ -55,3 +55,11 @@
   roles:
     - common-server
     - postfix
+
+- name: Set up Mattermost chat server
+  hosts: chat
+  become: true
+  roles:
+    - common-server
+    - forward-server-mail
+    - mattermost

--- a/group_vars/chat/public.yml
+++ b/group_vars/chat/public.yml
@@ -1,0 +1,9 @@
+---
+COMMON_SERVER_NO_BACKUPS: true
+
+SANITY_CHECK_LIVE_PORTS:
+  - host: localhost
+    port: 443
+    message: "Cannot connect to HTTPS port."
+
+MATTERMOST_OPS_EMAIL: "{{ OPS_EMAIL }}"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-ansible==2.0.1
+ansible==2.3.2
 netaddr==0.7.19

--- a/requirements.yml
+++ b/requirements.yml
@@ -60,3 +60,7 @@
 - name: postfix
   src: https://github.com/open-craft/ansible-postfix
   version: origin/master
+
+- name: mattermost
+  src: https://github.com/open-craft/ansible-mattermost
+  version: origin/master


### PR DESCRIPTION
This adds the play and the new role dependency for the chat server.  Until https://github.com/open-craft/ansible-mattermost/pull/1 and https://github.com/open-craft/ansible-forward-server-mail/pull/3 are merged, we use the feature branches of these repos in the dependencies.  Before merging this PR, we need to change them back to `origin/master`.