### PR TITLE
Remove useles group variables.

### DIFF
--- a/group_vars/all/public.yml
+++ b/group_vars/all/public.yml
@@ -3,10 +3,6 @@ tarsnap_cache: /var/tarsnap/cache
 tarsnap_cron_hour: "*"
 tarsnap_tarsnapper_conf: "{{ playbook_dir }}/opencraft-roles/roles/tarsnap/files/conf/tarsnapper.{{ inventory_hostname }}.conf"
 
-OPS_EMAIL: 'ops@example.com'
-FORWARD_MAIL_SMTP_FROM: "ops@example.com"
-
 FORWARD_MAIL_RELAY_MAIL_TO: '{{ OPS_EMAIL }}'
 COMMON_SERVER_ETCKEEPER_COMMIT_EMAIL: '{{ OPS_EMAIL }}'
 security_autoupdate_mail_to: '{{ OPS_EMAIL }}'
-


### PR DESCRIPTION
These variables take precedence over variables set in the inventory group_vars, so we remove them here.