### PR TITLE
Add Crafty and the link shortener.

### DIFF
--- a/deploy-all.yml
+++ b/deploy-all.yml
@@ -63,3 +63,5 @@
     - common-server
     - forward-server-mail
     - mattermost
+    - crafty
+    - link-shortener

--- a/requirements.yml
+++ b/requirements.yml
@@ -64,3 +64,11 @@
 - name: mattermost
   src: https://github.com/open-craft/ansible-mattermost
   version: origin/master
+
+- name: crafty
+  src: https://github.com/open-craft/ansible-crafty
+  version: origin/master
+
+- name: link-shortener
+  src: https://github.com/open-craft/ansible-link-shortener
+  version: origin/master


### PR DESCRIPTION
Before merging, we need to merge https://github.com/open-craft/ansible-crafty/pull/1 and https://github.com/open-craft/ansible-link-shortener/pull/1 and update the branch names in the requirements file to `master`.